### PR TITLE
Enable SCL PHP for interactive users.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for OULibraries.sclphp
+
+sclphp_global: true

--- a/files/enablephp56.sh
+++ b/files/enablephp56.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+source scl_source enable rh-php56

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,6 +12,15 @@
       ^;date.timezone =$
     replace: "date.timezone = America/Chicago"
 
+- name: Enable SCL PHP 5.6 for interactive users
+  copy:
+    src: enablephp56.sh
+    dest: /etc/profile.d
+    mode: 0755
+    owner: root
+    group: wheel
+  when: sclphp_global
+
 # - name: Disable display of errors in browser
 #   replace:
 #     dest: /etc/opt/rh/rh-php56/php.ini


### PR DESCRIPTION
Adds the ability to toggle enabling SCL installed PHP for all interactive users and makes that the default. 

Motivation and Context
----------------------
The d7 role needs SCL enabled for interactive use most of the time. 

How Has This Been Tested?
-------------------------
Small change, tested in dev. 
