### PR TITLE
Cbennett versioning

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,7 +20,6 @@
     name: "{{sclphp_version}}-php-fpm"
     state: started
     enabled: yes
-    force: yes
 
 - name: Set PHP timezone
   replace:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,9 +1,26 @@
 ---
-- name: Enable and start PHP FPM service
+
+- name: Check for existing installations
+  find:
+    path: "/opt/rh/"
+    file_type: directory
+    patterns: "rh-php*"
+  register: old_versions
+
+- name: Ensure all SCLPHP versions are stopped and disabled
+  service:
+    name: "{{ item.path | basename }}-php-fpm"
+    state: stopped
+    enabled: false
+  with_items:
+    - "{{ old_versions.files }}"
+
+- name: Enable and start defined PHP FPM service
   service:
     name: "{{sclphp_version}}-php-fpm"
     state: started
     enabled: yes
+    force: yes
 
 - name: Set PHP timezone
   replace:

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -311,7 +311,7 @@ pm.max_requests = 500
 ; The log file for slow requests
 ; Default Value: not set
 ; Note: slowlog is mandatory if request_slowlog_timeout is set
-slowlog = /var/opt/rh/rh-php56/log/php-fpm/www-slow.log
+slowlog = /var/opt/rh/{{ sclphp_version }}/log/php-fpm/www-slow.log
 
 ; The timeout for serving a single request after which a PHP backtrace will be
 ; dumped to the 'slowlog' file. A value of '0s' means 'off'.
@@ -405,12 +405,12 @@ slowlog = /var/opt/rh/rh-php56/log/php-fpm/www-slow.log
 ;                specified at startup with the -d argument
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
 ;php_flag[display_errors] = off
-php_admin_value[error_log] = /var/opt/rh/rh-php56/log/php-fpm/www-error.log
+php_admin_value[error_log] = /var/opt/rh/{{ sclphp_version }}/log/php-fpm/www-error.log
 php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 128M
 
 ; Set session path to a directory owned by process user
 php_value[session.save_handler] = files
-php_value[session.save_path]    = /var/opt/rh/rh-php56/lib/php/session
-php_value[soap.wsdl_cache_dir]  = /var/opt/rh/rh-php56/lib/php/wsdlcache
+php_value[session.save_path]    = /var/opt/rh/{{ sclphp_version }}/lib/php/session
+php_value[soap.wsdl_cache_dir]  = /var/opt/rh/{{ sclphp_version }}/lib/php/wsdlcache
 


### PR DESCRIPTION
Enable and implement SCLPHP Versioning, allowing multiple versions to be installed and a specified one to be enabled. 

Motivation and Context
----------------------
SCLPHP does not handle being upgraded as nicely as desired, these changes check for previous installations, stop and disable them in SystemD, and then install and enable the desired version. 

How Has This Been Tested?
-------------------------
Implemented on OJS3-Upgrade a few times
